### PR TITLE
Update to the M/monit 3.4 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,48 @@
-mmonit-ruby
-===========
+# mmonit-ruby
 
 Ruby interface for M/Monit
 
-All the commands listed here are currently available:
+A subset of the [M/Monit HTTP API](http://mmonit.com/documentation/http-api/) commands are currently available. Requests are currently read-only.
 
-http://mmonit.com/wiki/MMonit/HTTP-API
+## Available Commands
 
-Requests are read-only until I find a way to do more.
+* `connect` - Connect to M/Monit and establish a session
+* `status` - Status overview
+* `status_detailed(id_or_fqdn)` - Detailed status for a specified host
+  * `id_or_fqdn` - Either the numeric id or the fully-qualified domain name for a host
+* `events` - Events overview
+* `event(id)` - Detailed information about an event
+  * `id` - The numeric id for an event
+* `hosts` - A list of hosts
+* `host(id_or_fqdn)` - Detailed information about a specified host
+  * `id_or_fqdn` - Either the numeric id or the fully-qualified domain name for a host
+* `users` - A list of users
+* `user(id)` - Detailed information about a user
+  * `id` - The numeric id for a user
+* `groups` - A list of groups
 
+## Usage
 
+    require 'mmonit-ruby'
 
+    mmonit = MMonit::Connection.new({
+            :ssl => true,
+            :username => 'USERNAME',
+            :password => 'PASSWORD',
+            :address => 'example.com',
+            :port => '443'
+    })
 
-mmonit = MMonit::Connection.new({
-        :ssl => true,
-        :username => 'USERNAME',
-        :password => 'PASSWORD',
-        :address => 'example.com',
-        :port => '443'
-})
+    mmonit.connect
 
-mmonit.connect
+    hosts = mmonit.hosts
 
-hosts = mmonit.hosts
-
-p hosts
-
-
+## Custom Requests
 
 Custom requests can be made like:
 
-mmonit.request(path, [body])
+    require 'mmonit-ruby'
 
-body is optional
+    mmonit.request(path, [body])
+
+`body` is optional

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -87,7 +87,7 @@ module MMonit
 		# Helpers
 		def find_host(id_or_fqdn)
 			hosts = self.hosts rescue []
-			host = hosts.select{ |h| h['id'] == id_or_fqdn || h['host'] == id_or_fqdn }
+			host = hosts.select{ |h| h['id'] == id_or_fqdn || h['hostname'] == id_or_fqdn }
 			host.empty? ? nil : host.first
 		end
 

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -47,8 +47,8 @@ module MMonit
 		end
 
 		def status_detailed(id_or_fqdn)
-			host = find_host(id_or_fqdn)
-			host.nil? ? nil : JSON.parse(self.request("/status/hosts/get?id=#{host['id']}").body)['records']['host'] rescue nil
+			status = find_status(id_or_fqdn)
+			status.nil? ? nil : JSON.parse(self.request("/status/hosts/get?id=#{status['id']}").body)['records']['host'] rescue nil
 		end
 
 		# Events API: http://mmonit.com/documentation/http-api/Methods/Events
@@ -89,6 +89,12 @@ module MMonit
 			hosts = self.hosts rescue []
 			host = hosts.select{ |h| h['id'] == id_or_fqdn || h['host'] == id_or_fqdn }
 			host.empty? ? nil : host.first
+		end
+
+		def find_status(id_or_fqdn)
+			statuses = self.status rescue []
+			status = statuses.select{ |s| s['id'] == id_or_fqdn || s['hostname'] == id_or_fqdn }
+			status.empty? ? nil : status.first
 		end
 
 		def request(path, body="", is_post = false, headers = {})

--- a/lib/mmonit/connection.rb
+++ b/lib/mmonit/connection.rb
@@ -47,8 +47,8 @@ module MMonit
 		end
 
 		def status_detailed(id_or_fqdn)
-			status = find_status(id_or_fqdn)
-			status.nil? ? nil : JSON.parse(self.request("/status/hosts/get?id=#{status['id']}").body)['records']['host'] rescue nil
+			id = find_status_id(id_or_fqdn)
+			id.nil? ? nil : JSON.parse(self.request("/status/hosts/get?id=#{id}").body)['records']['host'] rescue nil
 		end
 
 		# Events API: http://mmonit.com/documentation/http-api/Methods/Events
@@ -66,8 +66,8 @@ module MMonit
 		end
 
 		def host(id_or_fqdn)
-			host = find_host(id_or_fqdn)
-			host.nil? ? nil : JSON.parse(self.request("/admin/hosts/get?id=#{host['id']}").body) rescue nil
+			id = find_host_id(id_or_fqdn)
+			id.nil? ? nil : JSON.parse(self.request("/admin/hosts/get?id=#{id}").body) rescue nil
 		end
 
 		# Admin Users API: http://mmonit.com/documentation/http-api/Methods/Admin_Users
@@ -91,10 +91,24 @@ module MMonit
 			host.empty? ? nil : host.first
 		end
 
+		def find_host_id(id_or_fqdn)
+			return id_or_fqdn if id_or_fqdn.is_a?(Integer)
+
+			data = find_status(id_or_fqdn)
+			data.nil? ? nil : data['id']
+		end
+
 		def find_status(id_or_fqdn)
 			statuses = self.status rescue []
 			status = statuses.select{ |s| s['id'] == id_or_fqdn || s['hostname'] == id_or_fqdn }
 			status.empty? ? nil : status.first
+		end
+
+		def find_status_id(id_or_fqdn)
+			return id_or_fqdn if id_or_fqdn.is_a?(Integer)
+
+			data = find_status(id_or_fqdn)
+			data.nil? ? nil : data['id']
 		end
 
 		def request(path, body="", is_post = false, headers = {})


### PR DESCRIPTION
Update the M/monit API calls to M/monit 3.4. The basic read-only operations for the Status, Events, Users, Groups, and Hosts APIs are implemented.

Breaking changes:
- `alerts` was removed (the API is no longer available)
- `delete_host` was removed (the description indicated this was aimed at the read-only operations for now, this could/would be added back when the other CRUD functions of the admin API are completed)
